### PR TITLE
Teknoparrot changed platform

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -552,6 +552,7 @@
           <core>mastersystem</core>
         </cores>
       </emulator>
+      <emulator name="mesen"/>
       <emulator name="ares">
         <cores>
           <core>MasterSystem</core>

--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -3211,7 +3211,7 @@
     <hardware>arcade</hardware>
     <extension>.teknoparrot .parrot .game .7z .zip .rar</extension>
     <command>"%HOME%\emulatorLauncher.exe" -gameinfo %GAMEINFOXML% %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
-    <platform>arcade</platform>
+    <platform>teknoparrot</platform>
     <theme>teknoparrot</theme>
     <emulators>
       <emulator name="teknoparrot" />


### PR DESCRIPTION
Screenscraper now has an official Teknoparrot platform, this PR to align with ES platform ID