### PR TITLE
remove .txt from neogeocd so _info.txt doesn't show up as a game

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -299,7 +299,7 @@
     <release>1994</release>
     <hardware>console</hardware>
     <path>~\..\roms\neogeocd</path>
-    <extension>.txt .m3u .cue .iso .cso .chd .zip .7z</extension>
+    <extension>.m3u .cue .iso .cso .chd .zip .7z</extension>
     <command>"%HOME%\emulatorLauncher.exe" -gameinfo %GAMEINFOXML% %CONTROLLERSCONFIG% -system %SYSTEM% -emulator %EMULATOR% -core %CORE% -rom %ROM%</command>
     <emulators>
       <emulator name="libretro">


### PR DESCRIPTION
not sure how “.txt” got in as a valid extension.  thought I’d remove it so “_info” doesn’t show up as a game.  great job on building a bridge for Batocera Linux folks into Windows!