### PR TITLE
Add libretro mame cores to Gaelco system

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -452,6 +452,13 @@
       <emulator name="demul-old">
         <core>gaelco</core>
       </emulator>
+      <emulator name="libretro">
+        <cores>
+          <core>mame</core>
+          <core>mame2016</core>
+          <core>mame2014</core>
+        </cores>
+      </emulator>
     </emulators>
     <platform>arcade</platform>
     <theme>gaelco</theme>


### PR DESCRIPTION
Adding libretro mame latest, 2016 and 2014 cores to Gaelco system supporting games that are not supported by Demul. 

Radikal Bikers, Speed Up, Surf Planet and Football Power are all playable in libretro mame latest. Both Radikal Bikers and Speed Up are also playable in libretro mame 2016 and libretro mame 2014. Surf Planet is also playable in libretro mame 2016 iirc.

libretro mame 2012 and earlier cores are crashing with any game, hence they're not included.

Demul is not compatible with any of the abovementioned games.