### PR TITLE
Fix Sega CD name

### DIFF
--- a/system/templates/emulationstation/es_systems.cfg
+++ b/system/templates/emulationstation/es_systems.cfg
@@ -701,7 +701,7 @@
   </system>
   <system>
     <name>segacd</name>
-    <fullname>Mega CD</fullname>
+    <fullname>Sega CD</fullname>
     <manufacturer>Sega</manufacturer>
     <release>1991</release>
     <hardware>extension</hardware>


### PR DESCRIPTION
segacd had wrong `fullname`. Mega CD was the european/japanese name of this system, while Sega CD was used in the US. Since the system name is segacd, for 100% coherence also its full name should be Sega CD.

PS. segacd is already called "Sega CD" also in Batocera